### PR TITLE
Adding MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include yampy/apis/ *.py


### PR DESCRIPTION
This file appears to be a requirement for inclusion of modules underneath the primary. I built the distributable and inspected it. It now includes the yampy/apis/.
