### PR TITLE
Group related API

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -31,6 +31,13 @@ UsersAPI object
 .. autoclass:: UsersAPI
    :members:
 
+GroupsAPI object
+---------------
+
+.. module:: yampy.apis
+.. autoclass:: GroupsAPI
+   :members:
+
 Client object
 -------------
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -122,6 +122,40 @@ property on your ``Yammer`` instance. These are just a few examples, see the
     yammer.users.suspend(a_user)
     yammer.users.delete(a_user)
 
+Groups
+~~~~~
+
+You can make `group-related requests using the ``groups``
+property on your ``Yammer`` instance. These are just a few examples, see the
+:class:`yampy.apis.GroupsAPI` class for details::
+
+    import yampy
+
+    yammer = yampy.Yammer(access_token=access_token)
+
+    # Get a list of all groups in your network
+    yammer.groups.all()
+    # Get a list of all groups of current user
+    yammer.groups.all(mine=True)
+
+    # View a specific group
+    yammer.groups.find(a_group_id)
+
+    # Get members of specific group
+    yammer.groups.members(a_group_id)
+
+    # Join a specific group
+    yammer.groups.join(a_group_id)
+
+    # Leave a specific group
+    yammer.groups.leave(a_group_id)
+
+    # Create a new group
+    yammer.groups.create("My new group", private=True)
+
+    # delete a group
+    yammer.groups.delete(a_group_id)
+
 Other API endpoints
 ~~~~~~~~~~~~~~~~~~~
 

--- a/livetests/groups_test.py
+++ b/livetests/groups_test.py
@@ -1,0 +1,26 @@
+"""
+Tests for getting groups.
+"""
+
+from unittest import TestCase
+
+from livetests.support import skip_without_environment_variable
+import yampy
+
+
+class GroupsIntegrationTest(TestCase):
+
+    @skip_without_environment_variable("YAMMER_ACCESS_TOKEN")
+    def test_reading_and_updating_current_user(self, access_token):
+        yammer = yampy.Yammer(access_token)
+        test_group_name = 'Test Group'
+        cur_user = yammer.users.find_current()
+
+        new_group = yammer.groups.create(test_group_name)
+        self.assertIn("creator_id", new_group)
+        self.assertIn("full_name", new_group)
+        self.assertEqual(new_group.full_name, test_group_name)
+        self.assertEqual(new_group.creator_id, cur_user.id)
+
+        result = yammer.groups.delete(new_group)
+        self.assertTrue(result)

--- a/tests/apis/groups_test.py
+++ b/tests/apis/groups_test.py
@@ -1,0 +1,184 @@
+from mock import Mock
+
+from tests.support.unit import TestCaseWithMockClient
+from yampy.apis import GroupsAPI
+
+
+class GroupsAPIAllTest(TestCaseWithMockClient):
+
+    def setUp(self):
+        super(GroupsAPIAllTest, self).setUp()
+        self.groups_api = GroupsAPI(client=self.mock_client)
+
+    def test_all(self):
+        groups = self.groups_api.all()
+
+        self.mock_client.get.assert_called_once_with("/groups")
+        self.assertEquals(self.mock_get_response, groups)
+
+    def test_all_with_reverse(self):
+        groups = self.groups_api.all(reverse=True)
+
+        self.mock_client.get.assert_called_once_with(
+            "/groups",
+            reverse="true",
+        )
+        self.assertEquals(self.mock_get_response, groups)
+
+    def test_find_current(self):
+        current_user_groups = self.groups_api.all(mine=True)
+
+        self.mock_client.get.assert_called_once_with("/groups", mine="true")
+        self.assertEquals(self.mock_get_response, current_user_groups)
+
+
+class GroupsAPIFindTest(TestCaseWithMockClient):
+
+    def setUp(self):
+        super(GroupsAPIFindTest, self).setUp()
+        self.groups_api = GroupsAPI(client=self.mock_client)
+
+    def test_find(self):
+        found_group = self.groups_api.find(13)
+
+        self.mock_client.get.assert_called_once_with("/groups/13")
+        self.assertEquals(self.mock_get_response, found_group)
+
+    def test_find_passing_id_as_a_dict(self):
+        found_group = self.groups_api.find({"id": 31})
+
+        self.mock_client.get.assert_called_once_with("/groups/31")
+        self.assertEquals(self.mock_get_response, found_group)
+
+    def test_find_passing_id_as_an_object(self):
+        found_group = self.groups_api.find(Mock(id=27))
+
+        self.mock_client.get.assert_called_once_with("/groups/27")
+        self.assertEquals(self.mock_get_response, found_group)
+
+
+class GroupsUsersAPICreateTest(TestCaseWithMockClient):
+
+    def setUp(self):
+        super(GroupsUsersAPICreateTest, self).setUp()
+        self.groups_api = GroupsAPI(client=self.mock_client)
+
+    def test_create_public_group(self):
+        created_group = self.groups_api.create("Test Public group")
+
+        self.mock_client.post.assert_called_once_with(
+            "/groups",
+            name="Test Public group",
+            private="false",
+        )
+        self.assertEquals(self.mock_post_response, created_group)
+
+    def test_create_private_group(self):
+        created_group = self.groups_api.create(
+            "Test Private group", private=True)
+
+        self.mock_client.post.assert_called_once_with(
+            "/groups",
+            name="Test Private group",
+            private="true",
+        )
+        self.assertEquals(self.mock_post_response, created_group)
+
+
+class GroupsAPIDeleteTest(TestCaseWithMockClient):
+
+    def setUp(self):
+        super(GroupsAPIDeleteTest, self).setUp()
+        self.groups_api = GroupsAPI(client=self.mock_client)
+
+    def test_delete(self):
+        delete_result = self.groups_api.delete(123)
+
+        self.mock_client.delete.assert_called_once_with(
+            "/groups/123",
+            delete="true",
+        )
+        self.assertEquals(self.mock_delete_response, delete_result)
+
+    def test_delete_passing_id_as_a_dict(self):
+        delete_result = self.groups_api.delete({"id": 171})
+
+        self.mock_client.delete.assert_called_once_with(
+            "/groups/171",
+            delete="true",
+        )
+        self.assertEquals(self.mock_delete_response, delete_result)
+
+    def test_delete_passing_id_as_an_object(self):
+        delete_result = self.groups_api.delete(Mock(id=125))
+
+        self.mock_client.delete.assert_called_once_with(
+            "/groups/125",
+            delete="true",
+        )
+        self.assertEquals(self.mock_delete_response, delete_result)
+
+
+class GroupsAPIJoinTest(TestCaseWithMockClient):
+
+    def setUp(self):
+        super(GroupsAPIJoinTest, self).setUp()
+        self.groups_api = GroupsAPI(client=self.mock_client)
+
+    def test_join(self):
+        response = self.groups_api.join(171)
+
+        self.mock_client.post.assert_called_once_with(
+            "/group_memberships",
+            group_id=171,
+        )
+        self.assertEquals(self.mock_post_response, response)
+
+    def test_join_passing_id_as_a_dict(self):
+        response = self.groups_api.join({"id": 171})
+
+        self.mock_client.post.assert_called_once_with(
+            "/group_memberships",
+            group_id=171,
+        )
+        self.assertEquals(self.mock_post_response, response)
+
+    def test_join_passing_id_as_an_object(self):
+        response = self.groups_api.join(Mock(id=125))
+
+        self.mock_client.post.assert_called_once_with(
+            "/group_memberships",
+            group_id=125,
+        )
+        self.assertEquals(self.mock_post_response, response)
+
+
+class GroupsAPILeaveTest(TestCaseWithMockClient):
+
+    def setUp(self):
+        super(GroupsAPILeaveTest, self).setUp()
+        self.groups_api = GroupsAPI(client=self.mock_client)
+
+    def test_leave(self):
+        self.groups_api.leave(142)
+
+        self.mock_client.delete.assert_called_once_with(
+            "/group_memberships",
+            group_id=142,
+        )
+
+    def test_leave_passing_id_as_a_dict(self):
+        self.groups_api.leave({"id": 171})
+
+        self.mock_client.delete.assert_called_once_with(
+            "/group_memberships",
+            group_id=171,
+        )
+
+    def test_leave_passing_id_as_an_object(self):
+        self.groups_api.leave(Mock(id=125))
+
+        self.mock_client.delete.assert_called_once_with(
+            "/group_memberships",
+            group_id=125,
+        )

--- a/yampy/apis/__init__.py
+++ b/yampy/apis/__init__.py
@@ -21,3 +21,4 @@ API classes which make requests to a group of Yammer API endpoints.
 
 from .messages import MessagesAPI
 from .users import UsersAPI
+from .groups import GroupsAPI

--- a/yampy/apis/groups.py
+++ b/yampy/apis/groups.py
@@ -12,7 +12,7 @@ class GroupsAPI(object):
 
     def __init__(self, client):
         """
-        Initializes a new UsersAPI that will use the given client object
+        Initializes a new GroupsAPI that will use the given client object
         to make HTTP requests.
         """
         self._client = client
@@ -77,6 +77,26 @@ class GroupsAPI(object):
         return self._client.delete(path, **self._argument_converter(
             group_id=group_id,
         ))
+
+    def create(self, name, private=False):
+        """
+        Create a group.
+
+        Return Group info
+        """
+        path = "/groups"
+        return self._client.post(path, **self._argument_converter(
+            name=name,
+            private=private,
+        ))
+
+    def delete(self, group_id):
+        """
+        Delete a group.
+
+        Return True if success
+        """
+        return self._client.delete(self._group_path(group_id), delete="true")
 
     def _group_path(self, group_id):
         return "/groups/%d" % extract_id(group_id)

--- a/yampy/apis/groups.py
+++ b/yampy/apis/groups.py
@@ -40,7 +40,7 @@ class GroupsAPI(object):
         """
         return self._client.get(self._group_path(group_id))
 
-    def members(self, group_id, page=None):
+    def members(self, group_id, page=None, reverse=None):
         """
         Returns the group identified by the given group_id.
 
@@ -48,9 +48,34 @@ class GroupsAPI(object):
 
         * page -- Enable pagination, and return the nth page of 50 users.
         """
-        path = "/groups/%d/members" % extract_id(group_id)
+        path = "/group_memberships"
         return self._client.get(path, **self._argument_converter(
             page=page,
+            reverse=reverse,
+        ))
+
+    def join(self, group_id):
+        """
+        Join the group identified by the given group_id.
+
+        Return True
+        """
+        path = "/group_memberships"
+        group_id = extract_id(group_id)
+        return self._client.post(path, **self._argument_converter(
+            group_id=group_id,
+        ))
+
+    def leave(self, group_id):
+        """
+        Leave the group identified by the given group_id.
+
+        Return True
+        """
+        path = "/group_memberships"
+        group_id = extract_id(group_id)
+        return self._client.delete(path, **self._argument_converter(
+            group_id=group_id,
         ))
 
     def _group_path(self, group_id):

--- a/yampy/apis/groups.py
+++ b/yampy/apis/groups.py
@@ -1,0 +1,57 @@
+from yampy.apis.utils import ArgumentConverter, none_filter
+from yampy.models import extract_id
+
+
+class GroupsAPI(object):
+
+    """
+    Provides an interface for accessing the groups related endpoints of the
+    Yammer API. You should not instantiate this class directly; use the
+    :meth:`yampy.Yammer.groups` method instead.
+    """
+
+    def __init__(self, client):
+        """
+        Initializes a new UsersAPI that will use the given client object
+        to make HTTP requests.
+        """
+        self._client = client
+        self._argument_converter = ArgumentConverter(
+            none_filter,
+        )
+
+    def all(self, mine=None, reverse=None):
+        """
+        Returns all the groups in the current user's network.
+
+        Customize the response using the keyword arguments:
+
+        * mine -- Only return group of current user.
+        * reverse -- return group in descending order by name.
+        """
+        return self._client.get("/groups", **self._argument_converter(
+            mine=mine,
+            reverse=reverse,
+        ))
+
+    def find(self, group_id):
+        """
+        Returns the group identified by the given group_id.
+        """
+        return self._client.get(self._group_path(group_id))
+
+    def members(self, group_id, page=None):
+        """
+        Returns the group identified by the given group_id.
+
+        Customize the response using the keyword arguments:
+
+        * page -- Enable pagination, and return the nth page of 50 users.
+        """
+        path = "/groups/%d/members" % extract_id(group_id)
+        return self._client.get(path, **self._argument_converter(
+            page=page,
+        ))
+
+    def _group_path(self, group_id):
+        return "/groups/%d" % extract_id(group_id)

--- a/yampy/apis/groups.py
+++ b/yampy/apis/groups.py
@@ -1,4 +1,4 @@
-from yampy.apis.utils import ArgumentConverter, none_filter
+from yampy.apis.utils import ArgumentConverter, none_filter, stringify_booleans
 from yampy.models import extract_id
 
 
@@ -17,7 +17,7 @@ class GroupsAPI(object):
         """
         self._client = client
         self._argument_converter = ArgumentConverter(
-            none_filter,
+            none_filter, stringify_booleans,
         )
 
     def all(self, mine=None, reverse=None):

--- a/yampy/yammer.py
+++ b/yampy/yammer.py
@@ -15,10 +15,12 @@
 # See the Apache Version 2.0 License for specific language governing
 # permissions and limitations under the License.
 
-from .apis import MessagesAPI, UsersAPI
+from .apis import MessagesAPI, UsersAPI, GroupsAPI
 from .client import Client
 
+
 class Yammer(object):
+
     """
     Main entry point for accessing the Yammer API.
 
@@ -70,3 +72,13 @@ class Yammer(object):
         if not hasattr(self, "_users_api"):
             self._users_api = UsersAPI(client=self._client)
         return self._users_api
+
+    @property
+    def groups(self):
+        """
+        Returns a :class:`yampy.apis.GroupsAPI` object which can be used to call
+        the Yammer API's user-related endpoints.
+        """
+        if not hasattr(self, "_groups_api"):
+            self._groups_api = GroupsAPI(client=self._client)
+        return self._groups_api


### PR DESCRIPTION
The pull includes following 
## api endpoints
1. Create group
2. Join group
3. Leave group
4. Delete group
5. Find members in group
6. Find group
7. See current user group
## Test Cases
1. Livetest
2. Unittest for all endpoints
## Docs

Updated api and added group related api examples
